### PR TITLE
Replace m.group(x) with m[x] for re.Match objects

### DIFF
--- a/fprime_fpp_install.py
+++ b/fprime_fpp_install.py
@@ -123,9 +123,9 @@ def get_package_version(tools_version):
         hash = tools_version[:8]
     elif full_version_matcher.match(tools_version):
         matched = full_version_matcher.match(tools_version)
-        version = matched.group(1)
-        commits = matched.group(2)
-        hash = matched.group(3)[:8]
+        version = matched[1]
+        commits = matched[2]
+        hash = matched[3][:8]
     return f"{ version }.dev{ commits }+g{ hash }"
 
 


### PR DESCRIPTION

This PR aims to replace the way we access groups in [re.Match](https://docs.python.org/3/library/re.html#match-objects) objects using getitem.

Since Python version 3.6, the ability to access groups from a match using [__getitem__](https://docs.python.org/3/library/re.html#re.Match.__getitem__) has been introduced. This is slightly shorter, easier to read and understand.
